### PR TITLE
Prevent wrong extension key substitution in vendor name

### DIFF
--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -333,13 +333,13 @@ class ExportController extends ActionController
             $string
         );
         $string = preg_replace(
-            '/MASK/',
-            $vendorName,
+            '/(.)mask\\1/',
+            '\\1' . $extensionKey . '\\1',
             $string
         );
         $string = preg_replace(
-            '/(.)mask\\1/',
-            '\\1' . $extensionKey . '\\1',
+            '/MASK/',
+            $vendorName,
             $string
         );
         $string = preg_replace(


### PR DESCRIPTION
Using "mask" inside the vendor name (happens with the default vendor name), it gets substituted second times.