### PR TITLE
Ensure only labels for mask fields are included in export

### DIFF
--- a/Classes/Aggregate/TcaAwareTrait.php
+++ b/Classes/Aggregate/TcaAwareTrait.php
@@ -106,7 +106,7 @@ trait TcaAwareTrait
     protected function replaceFieldLabels(array $fields, $table)
     {
         foreach ($fields as $field => &$configuration) {
-            if (0 === strpos($configuration['label'], 'LLL:')) {
+            if (0 !== strpos($field, 'tx_mask_') || 0 === strpos($configuration['label'], 'LLL:')) {
                 continue;
             }
             if (!isset($configuration['label']) && empty($this->maskConfiguration[$table]['elements'])) {
@@ -150,7 +150,7 @@ trait TcaAwareTrait
     protected function replaceItemsLabels(array $fields, $table)
     {
         foreach ($fields as $field => &$configuration) {
-            if (empty($configuration['config']['items'])) {
+            if (0 !== strpos($field, 'tx_mask_') || empty($configuration['config']['items'])) {
                 continue;
             }
             foreach ($configuration['config']['items'] as $key => &$item) {


### PR DESCRIPTION
Currently all non-translated labels of TCA fields and items are included
in the export. This patch ensures only mask fields are processed.