### PR TITLE
Support non-array (non-select) colPos configuration

### DIFF
--- a/Classes/Aggregate/InlineContentCTypeAggregate.php
+++ b/Classes/Aggregate/InlineContentCTypeAggregate.php
@@ -79,8 +79,8 @@ class TcaCTypeItem implements FormDataProviderInterface
     public function addData(array \$result)
     {
         if ('tt_content' !== \$result['tableName']
-            || empty(\$result['databaseRow']['colPos'][0])
-            || 999 !== (int)\$result['databaseRow']['colPos'][0]
+            || empty(\$result['databaseRow']['colPos'])
+            || (is_array(\$result['databaseRow']['colPos']) ? 999 !== (int)\$result['databaseRow']['colPos'][0] : 999 !== (int)\$result['databaseRow']['colPos'])
         ) {
             return \$result;
         }


### PR DESCRIPTION
Users may change the TCA configuration of tt_contents colPos field from
select to any other (input) type. This changes the processing of the
database value from array to plain value. The patch ensures the
generated DataProvider code can handle both cases.