### PR TITLE
Improve PHP file output

### DIFF
--- a/Classes/Aggregate/AbstractOverridesAggregate.php
+++ b/Classes/Aggregate/AbstractOverridesAggregate.php
@@ -54,6 +54,8 @@ abstract class AbstractOverridesAggregate extends AbstractAggregate implements L
 \\TYPO3\\CMS\\Core\\Utility\\ExtensionManagementUtility::addTCAcolumns('{$this->table}', \$tempColumns);
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
     }
 }

--- a/Classes/Aggregate/BackendPreviewAggregate.php
+++ b/Classes/Aggregate/BackendPreviewAggregate.php
@@ -84,6 +84,8 @@ EOS
 );
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
     }
 
@@ -100,6 +102,8 @@ EOS
     MASK\Mask\Hooks\PageLayoutViewDrawItem::class;
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
 
         $rootPaths = $this->getFluidRootPaths();

--- a/Classes/Aggregate/ContentElementIconAggregate.php
+++ b/Classes/Aggregate/ContentElementIconAggregate.php
@@ -98,6 +98,8 @@ EOS;
 \$GLOBALS['TCA']['{$this->table}']['ctrl']['typeicon_classes']['mask_{$key}'] = '{$iconIdentifier}';
 
 EOS
+                ,
+                PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
             );
         }
 
@@ -110,6 +112,8 @@ EOS
 $iconRegistryConfiguration
 
 EOS
+                ,
+                PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
             );
         }
     }

--- a/Classes/Aggregate/ContentRenderingAggregate.php
+++ b/Classes/Aggregate/ContentRenderingAggregate.php
@@ -100,6 +100,8 @@ EOS
 );
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
 
         foreach ($this->maskConfiguration[$this->table]['elements'] as $element) {

--- a/Classes/Aggregate/InlineContentCTypeAggregate.php
+++ b/Classes/Aggregate/InlineContentCTypeAggregate.php
@@ -56,6 +56,8 @@ class InlineContentCTypeAggregate extends AbstractInlineContentAggregate impleme
 ];
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
 
         $this->addPhpFile(

--- a/Classes/Aggregate/InlineContentColPosAggregate.php
+++ b/Classes/Aggregate/InlineContentColPosAggregate.php
@@ -53,6 +53,8 @@ class InlineContentColPosAggregate extends AbstractInlineContentAggregate implem
 ];
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
 
         $flattenedInlineFields = [];

--- a/Classes/Aggregate/NewContentElementWizardAggregate.php
+++ b/Classes/Aggregate/NewContentElementWizardAggregate.php
@@ -74,6 +74,8 @@ EOS
 );
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
     }
 

--- a/Classes/Aggregate/PhpAwareInterface.php
+++ b/Classes/Aggregate/PhpAwareInterface.php
@@ -16,6 +16,9 @@ namespace IchHabRecht\MaskExport\Aggregate;
 
 interface PhpAwareInterface
 {
+    const PHPFILE_DEFINED_TYPO3_MODE = 1;
+    const PHPFILE_CLOSURE_FUNCTION = 2;
+
     /**
      * @return array
      */

--- a/Classes/Aggregate/PhpAwareTrait.php
+++ b/Classes/Aggregate/PhpAwareTrait.php
@@ -32,22 +32,31 @@ trait PhpAwareTrait
     /**
      * @param string $fileIdentifier
      * @param string $content
+     * @param int $flags
      */
-    protected function addPhpFile($fileIdentifier, $content)
+    protected function addPhpFile($fileIdentifier, $content, $flags = 0)
     {
-        $this->phpFiles[$fileIdentifier] = $content;
+        $this->phpFiles[$fileIdentifier] = [
+            'content' => $content,
+            'flags' => $flags,
+        ];
     }
 
     /**
      * @param string $fileIdentifier
      * @param string $content
+     * @param array $flags
      */
-    protected function appendPhpFile($fileIdentifier, $content)
+    protected function appendPhpFile($fileIdentifier, $content, $flags = 0)
     {
         if (!isset($this->phpFiles[$fileIdentifier])) {
-            $this->phpFiles[$fileIdentifier] = '';
+            $this->phpFiles[$fileIdentifier] = [
+                'content' => '',
+                'flags' => 0,
+            ];
         }
 
-        $this->phpFiles[$fileIdentifier] .= $content;
+        $this->phpFiles[$fileIdentifier]['content'] .= $content;
+        $this->phpFiles[$fileIdentifier]['flags'] |= $flags;
     }
 }

--- a/Classes/Aggregate/TcaAggregate.php
+++ b/Classes/Aggregate/TcaAggregate.php
@@ -62,6 +62,8 @@ class TcaAggregate extends AbstractAggregate implements LanguageAwareInterface, 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('{$tableList}');
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
     }
 

--- a/Classes/Aggregate/TtContentOverridesAggregate.php
+++ b/Classes/Aggregate/TtContentOverridesAggregate.php
@@ -72,6 +72,8 @@ class TtContentOverridesAggregate extends AbstractOverridesAggregate
 ];
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
         foreach ($newTypeFields as $type => $_) {
             $this->addLabel(
@@ -89,6 +91,8 @@ EOS
 ];
 
 EOS
+                ,
+                PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
             );
         }
 
@@ -100,6 +104,8 @@ EOS
 \$GLOBALS['TCA']['{$this->table}']['types'] += \$tempTypes;
 
 EOS
+            ,
+            PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE | PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION
         );
     }
 }

--- a/Classes/FlagResolver/AbstractFlagResolver.php
+++ b/Classes/FlagResolver/AbstractFlagResolver.php
@@ -1,0 +1,65 @@
+<?php
+namespace IchHabRecht\MaskExport\FlagResolver;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2019 Nicole Cordes <typo3@cordes.co>, biz-design
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+abstract class AbstractFlagResolver implements FlagResolverInterface
+{
+    /**
+     * @var array
+     */
+    protected $flags = [];
+
+    public function __construct(DependencyOrderingService $dependencyOrderingService = null)
+    {
+        if ($dependencyOrderingService === null) {
+            $dependencyOrderingService = GeneralUtility::makeInstance(DependencyOrderingService::class);
+        }
+
+        $this->flags = $dependencyOrderingService->orderByDependencies($this->flags);
+    }
+
+    /**
+     * @param array $fileInformation
+     * @return array
+     */
+    public function resolveFlags(array $fileInformation)
+    {
+        $files = array_map(
+            function ($information) {
+                return $information['content'];
+            },
+            $fileInformation
+        );
+
+        foreach ($this->flags as $flagClassName => $_) {
+            if (!class_exists($flagClassName)) {
+                continue;
+            }
+
+            $flag = GeneralUtility::makeInstance($flagClassName);
+
+            foreach ($fileInformation as $file => $information) {
+                if ($flag->isEnabled($information['flags'])) {
+                    $files[$file] = $flag->execute($files[$file]);
+                }
+            }
+        }
+
+        return $files;
+    }
+}

--- a/Classes/FlagResolver/FlagInterface.php
+++ b/Classes/FlagResolver/FlagInterface.php
@@ -1,0 +1,30 @@
+<?php
+namespace IchHabRecht\MaskExport\FlagResolver;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2019 Nicole Cordes <typo3@cordes.co>, biz-design
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+interface FlagInterface
+{
+    /**
+     * @param int $flags
+     * @return bool
+     */
+    public function isEnabled($flags);
+
+    /**
+     * @param string $content
+     * @return string
+     */
+    public function execute($content);
+}

--- a/Classes/FlagResolver/FlagResolverInterface.php
+++ b/Classes/FlagResolver/FlagResolverInterface.php
@@ -1,0 +1,24 @@
+<?php
+namespace IchHabRecht\MaskExport\FlagResolver;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2019 Nicole Cordes <typo3@cordes.co>, biz-design
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+interface FlagResolverInterface
+{
+    /**
+     * @param array $fileInformation
+     * @return array
+     */
+    public function resolveFlags(array $fileInformation);
+}

--- a/Classes/FlagResolver/PhpFileFlag/ClosureFunctionFlag.php
+++ b/Classes/FlagResolver/PhpFileFlag/ClosureFunctionFlag.php
@@ -1,0 +1,41 @@
+<?php
+namespace IchHabRecht\MaskExport\FlagResolver\PhpFileFlag;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2019 Nicole Cordes <typo3@cordes.co>, biz-design
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use IchHabRecht\MaskExport\Aggregate\PhpAwareInterface;
+use IchHabRecht\MaskExport\FlagResolver\FlagInterface;
+
+class ClosureFunctionFlag implements FlagInterface
+{
+    /**
+     * @param int $flags
+     * @return bool
+     */
+    public function isEnabled($flags)
+    {
+        return ($flags & PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION) === PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION;
+    }
+
+    public function execute($content)
+    {
+        return <<<EOS
+call_user_func(function () {
+
+{$content}
+});
+
+EOS;
+    }
+}

--- a/Classes/FlagResolver/PhpFileFlag/DefinedTypo3ModeFlag.php
+++ b/Classes/FlagResolver/PhpFileFlag/DefinedTypo3ModeFlag.php
@@ -1,0 +1,44 @@
+<?php
+namespace IchHabRecht\MaskExport\FlagResolver\PhpFileFlag;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2019 Nicole Cordes <typo3@cordes.co>, biz-design
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use IchHabRecht\MaskExport\Aggregate\PhpAwareInterface;
+use IchHabRecht\MaskExport\FlagResolver\FlagInterface;
+
+class DefinedTypo3ModeFlag implements FlagInterface
+{
+    /**
+     * @param int $flags
+     * @return bool
+     */
+    public function isEnabled($flags)
+    {
+        return ($flags & PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE) === PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE;
+    }
+
+    /**
+     * @param string $content
+     * @return string
+     */
+    public function execute($content)
+    {
+        return <<<EOS
+defined('TYPO3_MODE') || die();
+
+{$content}
+
+EOS;
+    }
+}

--- a/Classes/FlagResolver/PhpFileFlag/PhpStartTagFlag.php
+++ b/Classes/FlagResolver/PhpFileFlag/PhpStartTagFlag.php
@@ -1,0 +1,34 @@
+<?php
+namespace IchHabRecht\MaskExport\FlagResolver\PhpFileFlag;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2019 Nicole Cordes <typo3@cordes.co>, biz-design
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use IchHabRecht\MaskExport\FlagResolver\FlagInterface;
+
+class PhpStartTagFlag implements FlagInterface
+{
+    /**
+     * @param int $flags
+     * @return bool
+     */
+    public function isEnabled($flags)
+    {
+        return true;
+    }
+
+    public function execute($content)
+    {
+        return '<?php' . PHP_EOL . $content;
+    }
+}

--- a/Classes/FlagResolver/PhpFileFlagResolver.php
+++ b/Classes/FlagResolver/PhpFileFlagResolver.php
@@ -1,0 +1,37 @@
+<?php
+namespace IchHabRecht\MaskExport\FlagResolver;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2019 Nicole Cordes <typo3@cordes.co>, biz-design
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use IchHabRecht\MaskExport\FlagResolver\PhpFileFlag\ClosureFunctionFlag;
+use IchHabRecht\MaskExport\FlagResolver\PhpFileFlag\DefinedTypo3ModeFlag;
+use IchHabRecht\MaskExport\FlagResolver\PhpFileFlag\PhpStartTagFlag;
+
+class PhpFileFlagResolver extends AbstractFlagResolver
+{
+    protected $flags = [
+        ClosureFunctionFlag::class => [],
+        DefinedTypo3ModeFlag::class => [
+            'after' => [
+                ClosureFunctionFlag::class,
+            ],
+        ],
+        PhpStartTagFlag::class => [
+            'after' => [
+                ClosureFunctionFlag::class,
+                DefinedTypo3ModeFlag::class,
+            ],
+        ],
+    ];
+}

--- a/Tests/Functional/Controller/FlagResolver/PhpFileFlagResolverTest.php
+++ b/Tests/Functional/Controller/FlagResolver/PhpFileFlagResolverTest.php
@@ -1,0 +1,100 @@
+<?php
+namespace IchHabRecht\MaskExport\Tests\Functional\Controller\FlagResolver;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2019 Nicole Cordes <typo3@cordes.co>, biz-design
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+require_once __DIR__ . '/../AbstractExportControllerTestCase.php';
+
+use IchHabRecht\MaskExport\Tests\Functional\Controller\AbstractExportControllerTestCase;
+
+class PhpFileFlagResolverTest extends AbstractExportControllerTestCase
+{
+    /**
+     * @return array
+     */
+    public function closureFunctionIsAppliedDataProvider()
+    {
+        return [
+            'ext_localconf.php' => [
+                '/ext_localconf\.php/',
+            ],
+            'ext_tables.php' => [
+                '/ext_tables\.php/',
+            ],
+            'Configuration/TCA/Overrides/*' => [
+                '/Configuration\/TCA\/Overrides\/[^.]+\.php/',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider closureFunctionIsAppliedDataProvider
+     * @param string $filePattern
+     */
+    public function closureFunctionIsApplied($filePattern)
+    {
+        $files = [];
+        foreach ($this->files as $file => $content) {
+            if (preg_match($filePattern, $file)) {
+                $files[$file] = $content;
+            }
+        }
+
+        $this->assertNotEmpty($files);
+
+        foreach ($files as $file => $fileContent) {
+            $this->assertContains('call_user_func(function () {', $fileContent);
+        }
+    }
+
+    /**
+     * @return array
+     */
+    public function definedTypo3ModeIsAppliedDataProvider()
+    {
+        return [
+            'ext_localconf.php' => [
+                '/ext_localconf\.php/',
+            ],
+            'ext_tables.php' => [
+                '/ext_tables\.php/',
+            ],
+            'Configuration/TCA/Overrides/*' => [
+                '/Configuration\/TCA\/Overrides\/[^.]+\.php/',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider definedTypo3ModeIsAppliedDataProvider
+     * @param string $filePattern
+     */
+    public function definedTypo3ModeIsApplied($filePattern)
+    {
+        $files = [];
+        foreach ($this->files as $file => $content) {
+            if (preg_match($filePattern, $file)) {
+                $files[$file] = $content;
+            }
+        }
+
+        $this->assertNotEmpty($files);
+
+        foreach ($files as $file => $fileContent) {
+            $this->assertContains('defined(\'TYPO3_MODE\') || die();', $fileContent);
+        }
+    }
+}

--- a/Tests/Unit/FileCollection/PhpFileCollectionTest.php
+++ b/Tests/Unit/FileCollection/PhpFileCollectionTest.php
@@ -1,0 +1,63 @@
+<?php
+namespace IchHabRecht\MaskExport\Tests\Unit\FileCollection;
+
+/*
+ * This file is part of the TYPO3 extension mask_export.
+ *
+ * (c) 2016 Nicole Cordes <typo3@cordes.co>, CPS-IT GmbH
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use IchHabRecht\MaskExport\Aggregate\PhpAwareInterface;
+use IchHabRecht\MaskExport\FileCollection\PhpFileCollection;
+use IchHabRecht\MaskExport\FlagResolver\PhpFileFlagResolver;
+use Nimut\TestingFramework\TestCase\UnitTestCase;
+use TYPO3\CMS\Core\Service\DependencyOrderingService;
+
+class PhpFileCollectionTest extends UnitTestCase
+{
+    /**
+     * @test
+     */
+    public function getFilesCombinesPhpFileFlags()
+    {
+        $aggregateOne = $this->prophesize(PhpAwareInterface::class);
+        $aggregateOne->getPhpFiles()->willReturn(
+            [
+                'ext_tables.php' => [
+                    'content' => '',
+                    'flags' => PhpAwareInterface::PHPFILE_CLOSURE_FUNCTION,
+                ],
+            ]
+        );
+        $aggregateTwo = $this->prophesize(PhpAwareInterface::class);
+        $aggregateTwo->getPhpFiles()->willReturn(
+            [
+                'ext_tables.php' => [
+                    'content' => '',
+                    'flags' => PhpAwareInterface::PHPFILE_DEFINED_TYPO3_MODE,
+                ],
+            ]
+        );
+        $aggregateCollection = [
+            $aggregateOne->reveal(),
+            $aggregateTwo->reveal(),
+        ];
+
+        $dependencyOrderingService = new DependencyOrderingService();
+        $phpFileFlagResolver = new PhpFileFlagResolver($dependencyOrderingService);
+
+        $phpFileCollection = new PhpFileCollection($aggregateCollection, $phpFileFlagResolver);
+        $files = $phpFileCollection->getFiles();
+
+        $this->assertArrayHasKey('ext_tables.php', $files);
+        $this->assertContains('defined(\'TYPO3_MODE\') || die();', $files['ext_tables.php']);
+        $this->assertContains('call_user_func(function () {', $files['ext_tables.php']);
+    }
+}


### PR DESCRIPTION
To generate more "best practice" like PHP files, a flag system is
introduced to PhpAwareInterface file handling. This enables
handling of encapsulated closure function and TYPO3_MODE check header.