### PR TITLE
Allow name configuration in mask.json

### DIFF
--- a/Classes/Aggregate/ExtensionConfigurationAggregate.php
+++ b/Classes/Aggregate/ExtensionConfigurationAggregate.php
@@ -126,18 +126,10 @@ class ExtensionConfigurationAggregate extends AbstractAggregate implements PhpAw
      */
     protected function addMaskConfiguration()
     {
-        $maskConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['mask']);
-        if (empty($maskConfiguration['json'])) {
-            return;
-        }
-
-        $jsonFile = GeneralUtility::getFileAbsFileName($maskConfiguration['json']);
-        if (file_exists($jsonFile)) {
-            $content = file_get_contents($jsonFile);
-            $this->addPlainTextFile(
-                $this->escapeMaskExtensionKey('Configuration/Mask/mask.json'),
-                $this->escapeMaskExtensionKey($content)
-            );
-        }
+        $content = json_encode($this->maskConfiguration, JSON_PRETTY_PRINT);
+        $this->addPlainTextFile(
+            $this->escapeMaskExtensionKey('Configuration/Mask/mask.json'),
+            $this->escapeMaskExtensionKey($content)
+        );
     }
 }

--- a/Classes/Aggregate/ExtensionConfigurationAggregate.php
+++ b/Classes/Aggregate/ExtensionConfigurationAggregate.php
@@ -24,6 +24,17 @@ class ExtensionConfigurationAggregate extends AbstractAggregate implements PhpAw
     use PlainTextFileAwareTrait;
 
     /**
+     * Own constructor method to ensure that the mask configuration is not changed before export.
+     *
+     * @param array $maskConfiguration
+     */
+    public function __construct(array $maskConfiguration)
+    {
+        $this->maskConfiguration = $maskConfiguration;
+        $this->process();
+    }
+
+    /**
      * Adds typical extension files
      */
     protected function process()
@@ -122,7 +133,7 @@ class ExtensionConfigurationAggregate extends AbstractAggregate implements PhpAw
     }
 
     /**
-     * Adds mask.josn configuration file
+     * Adds mask.json configuration file
      */
     protected function addMaskConfiguration()
     {

--- a/Resources/Private/Backend/Templates/Export/List.html
+++ b/Resources/Private/Backend/Templates/Export/List.html
@@ -14,7 +14,7 @@
                             </label>
                             <div class="t3js-formengine-field-item">
                                 <div class="form-control-wrap">
-                                    <f:form.textfield value="" name="extensionName" placeholder="{extensionName}" id="extensionName" title="Extension Name" class="form-control" />
+                                    <f:form.textfield value="{extensionName}" name="extensionName" id="extensionName" title="Extension Name" class="form-control" />
                                 </div>
                             </div>
                         </div>
@@ -25,7 +25,7 @@
                             </label>
                             <div class="t3js-formengine-field-item">
                                 <div class="form-control-wrap">
-                                    <f:form.textfield value="" name="vendorName" placeholder="{vendorName}" id="vendorName" title="Vendor Name" class="form-control" />
+                                    <f:form.textfield value="{vendorName}" name="vendorName" id="vendorName" title="Vendor Name" class="form-control" />
                                 </div>
                             </div>
                         </div>
@@ -33,7 +33,7 @@
                         <div class="form-group col-sm-4">
                             <div class="t3js-formengine-field-item">
                                 <div class="form-control-wrap">
-                                    <f:form.submit name="submit" value="Save" class="btn btn-success col-sm-3" />
+                                    <f:form.submit name="submit" value="Preview" class="btn btn-success col-sm-3" />
                                     <f:form.hidden name="submit" value="" />
                                     <f:if condition="{composerMode}}">
                                         <f:then>

--- a/Tests/Functional/Controller/AbstractExportControllerTestCase.php
+++ b/Tests/Functional/Controller/AbstractExportControllerTestCase.php
@@ -16,7 +16,6 @@ namespace IchHabRecht\MaskExport\Tests\Functional\Controller;
 
 use IchHabRecht\MaskExport\Controller\ExportController;
 use Nimut\TestingFramework\TestCase\FunctionalTestCase;
-use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Mvc\Web\Request;
 use TYPO3\CMS\Extbase\Mvc\Web\Response;
@@ -57,16 +56,6 @@ abstract class AbstractExportControllerTestCase extends FunctionalTestCase
     ];
 
     /**
-     * @var string
-     */
-    protected $vendorName = 'IchHabRecht';
-
-    /**
-     * @var string
-     */
-    protected $extensionName = 'mask_example_export';
-
-    /**
      * @var array
      */
     protected $files = [];
@@ -85,12 +74,6 @@ abstract class AbstractExportControllerTestCase extends FunctionalTestCase
     protected function setUp()
     {
         parent::setUp();
-
-        // The export stores new extension names in backend user settings, so we need a pseudo user object here
-        $backendUser = new BackendUserAuthentication();
-        $backendUser->uc['mask_export']['vendorName'] = $this->vendorName;
-        $backendUser->uc['mask_export']['extensionName'] = $this->extensionName;
-        $GLOBALS['BE_USER'] = $backendUser;
 
         $objectManager = new ObjectManager();
 

--- a/Tests/Functional/Controller/Configuration/ExportControllerTest.php
+++ b/Tests/Functional/Controller/Configuration/ExportControllerTest.php
@@ -105,7 +105,7 @@ class ExportControllerTest extends AbstractExportControllerTestCase
     {
         $this->assertArrayHasKey('Configuration/Mask/mask.json', $this->files);
 
-        $this->assertStringEqualsFile(
+        $this->assertJsonStringEqualsJsonFile(
             __DIR__ . '/../../Fixtures/Configuration/mask-default.json',
             $this->files['Configuration/Mask/mask.json']
         );

--- a/Tests/Functional/Fixtures/Configuration/mask-default.json
+++ b/Tests/Functional/Fixtures/Configuration/mask-default.json
@@ -478,5 +478,9 @@
                 }
             }
         }
+    },
+    "mask_export": {
+        "extensionName": "mask_example_export",
+        "vendorName": "IchHabRecht"
     }
 }

--- a/Tests/Functional/Fixtures/Configuration/mask-empty-columns.json
+++ b/Tests/Functional/Fixtures/Configuration/mask-empty-columns.json
@@ -30,5 +30,9 @@
                 "key": "tabsimages"
             }
         }
+    },
+    "mask_export": {
+        "extensionName": "mask_example_export",
+        "vendorName": "IchHabRecht"
     }
 }


### PR DESCRIPTION
This patch reads and stores the extension and vendor names from/in mask.json file.
New order to find extension/vendor name:
- mask configuration
- user settings
- default names
