### PR TITLE
Add indexes to tt_content for parent fields

### DIFF
--- a/Classes/Aggregate/TcaAwareTrait.php
+++ b/Classes/Aggregate/TcaAwareTrait.php
@@ -88,6 +88,12 @@ trait TcaAwareTrait
                 $field . '_parent',
                 $definition
             );
+            $this->addSqlDefinitions(
+                'tt_content',
+                [
+                    'KEY ' . $field . '_parent' => '(' . $field . '_parent,pid,deleted)',
+                ]
+            );
         }
         if ('pages' === $table) {
             $this->addSqlDefinition(


### PR DESCRIPTION
To speed up database queries an own index for each parent field is added to tt_content table.
