### PR TITLE
Add Mask 5.0 and TYPO3 10 support

### DIFF
--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -80,8 +80,6 @@ class ExportController extends ActionController
 
     public function __construct(StorageRepository $storageRepository)
     {
-        parent::__construct();
-
         $this->maskConfiguration = (array)$storageRepository->load();
     }
 
@@ -98,10 +96,11 @@ class ExportController extends ActionController
 
         $this->view->assignMultiple(
             [
-                'composerMode' => Bootstrap::usesComposerClassLoading(),
+                'composerMode' => (defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE), //Bootstrap::usesComposerClassLoading(),
                 'vendorName' => $vendorName,
                 'extensionName' => $extensionName,
                 'files' => $files,
+                'activeTab' => 'mask_export'
             ]
         );
     }
@@ -182,7 +181,7 @@ class ExportController extends ActionController
         $this->writeExtensionFilesToPath($files, $extensionPath);
 
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        if (!Bootstrap::usesComposerClassLoading()) {
+        if (!(defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE)) {
             $managementService = $objectManager->get(ExtensionManagementService::class);
             $managementService->reloadPackageInformation($extensionName);
             $extension = $managementService->getExtension($extensionName);

--- a/Classes/Controller/ExportController.php
+++ b/Classes/Controller/ExportController.php
@@ -96,7 +96,7 @@ class ExportController extends ActionController
 
         $this->view->assignMultiple(
             [
-                'composerMode' => (defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE), //Bootstrap::usesComposerClassLoading(),
+                'composerMode' => (defined('TYPO3_COMPOSER_MODE') && TYPO3_COMPOSER_MODE),
                 'vendorName' => $vendorName,
                 'extensionName' => $extensionName,
                 'files' => $files,

--- a/Resources/Private/Backend/Layout/Default.html
+++ b/Resources/Private/Backend/Layout/Default.html
@@ -9,7 +9,7 @@
     <ul class="nav nav-tabs t3js-tabs" role="tablist" id="tabs-DTM-mask" data-store-last-tab="1">
         <li role="presentation" class="t3js-tabmenu-item{f:if(condition: '{activeTab} != \'mask_export\'', then: ' active')}">
             <f:link.action action="list" controller="Wizard" additionalParams="{aria-controls:'DTM-mask-1', role:'tab', data-toggle:'tab'}">
-                Mask
+                <f:translate key="tx_mask.all.mask" extensionName="mask_export" />
             </f:link.action>
         </li>
         <li role="presentation" class="t3js-tabmenu-item{f:if(condition: '{activeTab} == \'mask_export\'', then: ' active')}">

--- a/Resources/Private/Backend/Layout/Default.html
+++ b/Resources/Private/Backend/Layout/Default.html
@@ -1,0 +1,25 @@
+<f:be.container
+        pageTitle="Mask"
+        includeCssFiles="{0: '{f:uri.resource(path:\'Styles/styles.css\')}'}"
+        includeRequireJsModules="{
+	Modal:'TYPO3/CMS/Backend/Modal'
+	}"
+        includeJsFiles="{0: '{f:uri.resource(path:\'Scripts/libs.js\')}', 1: '{f:uri.resource(path:\'Scripts/scripts.js\')}'}"
+>
+    <ul class="nav nav-tabs t3js-tabs" role="tablist" id="tabs-DTM-mask" data-store-last-tab="1">
+        <li role="presentation" class="t3js-tabmenu-item{f:if(condition: '{activeTab} != \'mask_export\'', then: ' active')}">
+            <f:link.action action="list" controller="Wizard" additionalParams="{aria-controls:'DTM-mask-1', role:'tab', data-toggle:'tab'}">
+                Mask
+            </f:link.action>
+        </li>
+        <li role="presentation" class="t3js-tabmenu-item{f:if(condition: '{activeTab} == \'mask_export\'', then: ' active')}">
+            <f:link.action action="list" controller="Export" additionalParams="{aria-controls:'DTM-mask-2', role:'tab', data-toggle:'tab'}">
+                <f:translate key="tx_mask.all.export" extensionName="mask_export" />
+            </f:link.action>
+        </li>
+    </ul>
+
+    <f:flashMessages/>
+
+    <f:render section="content"/>
+</f:be.container>

--- a/Resources/Private/Backend/Templates/Export/List.html
+++ b/Resources/Private/Backend/Templates/Export/List.html
@@ -1,8 +1,6 @@
 <f:layout name="Default" />
 
 <f:section name="content">
-    <f:render partial="General/Tabs" arguments="{active: 'Preview'}" />
-
     <div class="tab-content">
         <div role="tabpanel" class="tab-pane active" id="DTM-mask-1">
             <div class="form-section">

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -12,6 +12,9 @@
 			<trans-unit id="config.contentElementIcons">
 				<source>Export icons for content elements: If enabled the export includes icons for content elements.</source>
 			</trans-unit>
+			<trans-unit id="tx_mask.all.mask">
+				<source>Mask</source>
+			</trans-unit>
 			<trans-unit id="tx_mask.all.export">
 				<source>Code Export</source>
 			</trans-unit>

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         }
     ],
     "require": {
-        "typo3/cms-core": "^7.6 || ^8.7 || ^9.5",
-        "typo3/cms-extbase": "^7.6 || ^8.7 || ^9.5",
-        "typo3/cms-fluid": "^7.6 || ^8.7 || ^9.5",
-        "mask/mask": "^2.0 || ^3.0 || ^4.0"
+        "typo3/cms-core": "^7.6 || ^8.7 || ^9.5 || ^10.4",
+        "typo3/cms-extbase": "^7.6 || ^8.7 || ^9.5 || ^10.4",
+        "typo3/cms-fluid": "^7.6 || ^8.7 || ^9.5 || ^10.4",
+        "mask/mask": "^2.0 || ^3.0 || ^4.0 || ^5.0"
     },
     "require-dev": {
-        "typo3/cms-fluid-styled-content": "^7.6 || ^8.7 || ^9.5",
+        "typo3/cms-fluid-styled-content": "^7.6 || ^8.7 || ^9.5 || ^10.4",
         "nimut/testing-framework": "2.x-dev || 3.x-dev || 4.x-dev"
     },
     "replace": {

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,10 +1,12 @@
 <?php
 
-$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['extbase']['extensions']['Mask']['modules']['tools_MaskMask']['controllers']['Export'] = [
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['extbase']['extensions']['Mask']['modules']['tools_MaskMask']['controllers']['IchHabRecht\MaskExport\Controller\ExportController'] = [
     'actions' => [
         'list',
         'save',
         'download',
         'install',
     ],
+    'alias' => 'Export',
+    'className' => 'IchHabRecht\MaskExport\Controller\ExportController'
 ];

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -10,6 +10,7 @@ config {
 
 module.tx_mask {
     view {
+        layoutRootPaths.42 = EXT:mask_export/Resources/Private/Backend/Layout/
         partialRootPaths.42 = EXT:mask_export/Resources/Private/Backend/Partials/
         templateRootPaths.42 = EXT:mask_export/Resources/Private/Backend/Templates/
     }


### PR DESCRIPTION
This adds basic support for Mask 5.0 and TYPO3 10. Testing with a few of my projects was done, but this is still to be considered as a work in progress, as the changes that were made will most likely also break support for older versions of Mask and TYPO3.

Maybe you can use this as a starting point for official Mask 5.0 and TYPO3 10 support.