### PR TITLE
[TASK] Change module label and fix code preview panels

### DIFF
--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -7,10 +7,10 @@
                 <source>Mask Export</source>
             </trans-unit>
             <trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
-                <source>TYPO3 Extension Manager</source>
+                <source>Export your Masks as an extension</source>
             </trans-unit>
             <trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
-                <source>Manages TYPO3 extensions from a central repository. TYPO3 extensions include plugins, modules, class extensions, configuration code, etc. &lt;br /&gt;&lt;em&gt;Access for 'admin' users only!&lt;/em&gt;</source>
+                <source>Use mask_export to export the content elements created with the mask extension to a separate extension.</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -7,10 +7,10 @@
                 <source>Mask Export</source>
             </trans-unit>
             <trans-unit id="mlang_labels_tablabel" resname="mlang_labels_tablabel">
-                <source>Export your Masks as an extension</source>
+                <source>Export your mask elements as extension</source>
             </trans-unit>
             <trans-unit id="mlang_labels_tabdescr" resname="mlang_labels_tabdescr">
-                <source>Use mask_export to export the content elements created with the mask extension to a separate extension.</source>
+                <source>Exports your mask content elements to a separate extension</source>
             </trans-unit>
         </body>
     </file>

--- a/Resources/Private/Templates/Export/List.html
+++ b/Resources/Private/Templates/Export/List.html
@@ -79,7 +79,7 @@
             <f:for each="{files}" as="fileContent" key="fileName" iteration="iterator">
                 <div class="panel panel-space panel-default">
                     <div class="panel-heading" role="tab" id="file-{iterator.cycle}-heading">
-                        <a class="collapsed" data-toggle="collapse" title="{fileName}" data-parent="#file-{iterator.cycle}-content" href="#file-{iterator.cycle}-content" aria-expanded="false" aria-controls="file-{iterator.cycle}-content">
+                        <a class="collapsed" data-bs-toggle="collapse" title="{fileName}" data-bs-parent="#file-{iterator.cycle}-content" href="#file-{iterator.cycle}-content" aria-expanded="false" aria-controls="file-{iterator.cycle}-content">
                             <span class="caret"></span>
                             {fileName}
                         </a>

--- a/Resources/Private/Templates/Export/List.html
+++ b/Resources/Private/Templates/Export/List.html
@@ -79,7 +79,7 @@
             <f:for each="{files}" as="fileContent" key="fileName" iteration="iterator">
                 <div class="panel panel-space panel-default">
                     <div class="panel-heading" role="tab" id="file-{iterator.cycle}-heading">
-                        <a class="collapsed" data-bs-toggle="collapse" title="{fileName}" data-bs-parent="#file-{iterator.cycle}-content" href="#file-{iterator.cycle}-content" aria-expanded="false" aria-controls="file-{iterator.cycle}-content">
+                        <a class="collapsed" data-toggle="collapse" data-bs-toggle="collapse" title="{fileName}" data-parent="#file-{iterator.cycle}-content" data-bs-parent="#file-{iterator.cycle}-content" href="#file-{iterator.cycle}-content" aria-expanded="false" aria-controls="file-{iterator.cycle}-content">
                             <span class="caret"></span>
                             {fileName}
                         </a>


### PR DESCRIPTION
* The label and description of the backend module have been changed (Resolves #167).
* The HTML attributes in the code preview panels have been fixed so that the individual panels can be toggled again.